### PR TITLE
ambiguous overload because of namespace

### DIFF
--- a/libconnman-qt/marshalutils.cpp
+++ b/libconnman-qt/marshalutils.cpp
@@ -31,7 +31,7 @@
  */
 
 #include <QDebug>
-#include <QDBusMetaType>
+#include <QDBusArgument> 
 #include "vpnconnection.h"
 
 #include "marshalutils.h"
@@ -183,6 +183,7 @@ QVariantMap MarshalUtils::propertiesToQml(const QVariantMap &fromDBus)
     return rv;
 }
 
+#include <QDBusMetaType>
 // Conversion to/from DBus/QML
 QHash<QString, MarshalUtils::conversionFunction> MarshalUtils::propertyConversions()
 {

--- a/libconnman-qt/marshalutils.cpp
+++ b/libconnman-qt/marshalutils.cpp
@@ -36,6 +36,11 @@
 
 #include "marshalutils.h"
 
+#if defined(__clang__) &&  __clang_major__ >= 11 || __GNUC__ >= 12
+Q_DBUS_EXPORT const QDBusArgument &operator>>(const QDBusArgument &a, RouteStructure &v);
+Q_DBUS_EXPORT QDBusArgument &operator<<(QDBusArgument &a, const RouteStructure &v);
+#endif
+
 // Empty namespace for local static functions
 namespace {
 

--- a/libconnman-qt/marshalutils.cpp
+++ b/libconnman-qt/marshalutils.cpp
@@ -41,9 +41,6 @@ Q_DBUS_EXPORT const QDBusArgument &operator>>(const QDBusArgument &a, RouteStruc
 Q_DBUS_EXPORT QDBusArgument &operator<<(QDBusArgument &a, const RouteStructure &v);
 #endif
 
-// Empty namespace for local static functions
-namespace {
-
 // Marshall the RouteStructure data into a D-Bus argument
 QDBusArgument &operator<<(QDBusArgument &argument, const RouteStructure &routestruct)
 {
@@ -126,8 +123,6 @@ QVariant convertRoutes (const QString &, const QVariant &value, bool toDBus) {
     }
     return variant;
 }
-
-} // Empty namespace
 
 template<typename T>
 inline QVariant extract(const QDBusArgument &arg)

--- a/libconnman-qt/vpnmanager.h
+++ b/libconnman-qt/vpnmanager.h
@@ -34,10 +34,10 @@
 #define VPNMANAGER_H
 
 #include <QObject>
+#include "vpnconnection.h"
 
 class VpnManagerPrivate;
 class VpnManager;
-class VpnConnection;
 
 // ==========================================================================
 // VpnManagerFactory

--- a/libconnman-qt/vpnmodel.h
+++ b/libconnman-qt/vpnmodel.h
@@ -34,9 +34,9 @@
 #define VPNMODEL_H
 
 #include <QAbstractListModel>
+#include "vpnmanager.h"
 
 class VpnModelPrivate;
-class VpnManager;
 class VpnConnection;
 
 /*


### PR DESCRIPTION
I am not sure if this right solution, the error messages says
```
/usr/include/qt/QtDBus/qdbusmetatype.h:68:7: error: ambiguous overload for ‘operator<<’ (operand types are ‘QDBusArgument’ and ‘const RouteStructure’)
   68 | { arg << *t; }
      |   ~~~~^~~~~
../../libconnman-qt/marshalutils.cpp:41:30: note: candidate: ‘QDBusArgument& operator<<(QDBusArgument&, const RouteStructure&)’
   41 | Q_DBUS_EXPORT QDBusArgument &operator<<(QDBusArgument &a, const RouteStructure &v);
      |                              ^~~~~~~~
../../libconnman-qt/marshalutils.cpp:48:16: note: candidate: ‘QDBusArgument& {anonymous}::operator<<(QDBusArgument&, const RouteStructure&)’
   48 | QDBusArgument &operator<<(QDBusArgument &argument, const RouteStructure &routestruct)
      |                ^~~~~~~~
```
The trouble is in adding of export definition outside of `namespace`. The comment says `Empty namespace for local static functions`. I don't understand reason to hide those functions inside of `{anonymous}::` namespace. It could be there for some purpose.

Please note I didn't tested behavior of library with this change yet.
